### PR TITLE
add s3 bucket to store images etc. for goobi

### DIFF
--- a/defaults.tf
+++ b/defaults.tf
@@ -10,7 +10,7 @@ variable "platform_team_account_id" {
   default = "760097843905"
 }
 
-  variable "admin_cidr_ingress" {
+variable "admin_cidr_ingress" {
   type = "list"
 }
 

--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -90,3 +90,19 @@ data "aws_iam_policy_document" "s3_read_workflow-configuration" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "s3_rw_workflow-data" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.workflow-data.arn}",
+      "${aws_s3_bucket.workflow-data.arn}/*",
+    ]
+  }
+}

--- a/iam_role_policy.tf
+++ b/iam_role_policy.tf
@@ -14,3 +14,8 @@ resource "aws_iam_role_policy" "ecs_goobi_s3_config_read" {
   role   = "${module.ecs_service.task_role_name}"
   policy = "${data.aws_iam_policy_document.s3_read_workflow-configuration.json}"
 }
+
+resource "aws_iam_role_policy" "ecs_goobi_s3_data_rw" {
+  role   = "${module.ecs_service.task_role_name}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-data.json}"
+}

--- a/s3.tf
+++ b/s3.tf
@@ -30,3 +30,12 @@ resource "aws_s3_bucket" "workflow-configuration" {
     prevent_destroy = true
   }
 }
+
+resource "aws_s3_bucket" "workflow-data" {
+  bucket = "wellcomedigitalworkflow-workflow-data"
+  acl    = "private"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to use S3 storage for Goobi, a bucket is needed with corresponding permissions for the service to access it.