### PR TITLE
Allow parallel EP and archive S3 usage for both on-premis and AWS systems

### DIFF
--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -138,14 +138,26 @@ data "aws_iam_policy_document" "s3_rw_workflow-harvesting-results" {
   }
 }
 
-data "aws_iam_policy_document" "allow_archive_access" {
+data "aws_iam_policy_document" "allow_external_export-bagit_access" {
   statement {
     actions   = ["s3:GetObject*"]
     resources = ["${aws_s3_bucket.workflow-export-bagit.arn}", "${aws_s3_bucket.workflow-export-bagit.arn}/*"]
-
     principals {
       type        = "AWS"
       identifiers = ["${var.platform_team_account_id}"]
+    }
+  }
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${aws_s3_bucket.workflow-export-bagit.arn}", "${aws_s3_bucket.workflow-export-bagit.arn}/*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.intranda_ep_user}"]
     }
   }
 }

--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -142,11 +142,13 @@ data "aws_iam_policy_document" "allow_external_export-bagit_access" {
   statement {
     actions   = ["s3:GetObject*"]
     resources = ["${aws_s3_bucket.workflow-export-bagit.arn}", "${aws_s3_bucket.workflow-export-bagit.arn}/*"]
+
     principals {
       type        = "AWS"
       identifiers = ["${var.platform_team_account_id}"]
     }
   }
+
   statement {
     actions = [
       "s3:ListBucket",
@@ -154,7 +156,9 @@ data "aws_iam_policy_document" "allow_external_export-bagit_access" {
       "s3:PutObject",
       "s3:DeleteObject",
     ]
+
     resources = ["${aws_s3_bucket.workflow-export-bagit.arn}", "${aws_s3_bucket.workflow-export-bagit.arn}/*"]
+
     principals {
       type        = "AWS"
       identifiers = ["${var.intranda_ep_user}"]

--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -191,6 +191,6 @@ data "aws_iam_policy_document" "s3_editorial_photography_upload_external" {
       "s3:DeleteObject",
     ]
 
-    resources = ["arn:aws:s3:::${var.ep_upload_external_bucket}", "arn:aws:s3:::${var.ep_upload_external_bucket}/${var.ep_upload_external_prefix}/*"]
+    resources = ["arn:aws:s3:::${var.ep_upload_external_bucket}", "arn:aws:s3:::${var.ep_upload_external_bucket}/*"]
   }
 }

--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -191,6 +191,6 @@ data "aws_iam_policy_document" "s3_editorial_photography_upload_external" {
       "s3:DeleteObject",
     ]
 
-    resources = ["${var.ep_upload_external_bucket}", "${var.ep_upload_external_bucket}/${var.ep_upload_external_prefix}/*"]
+    resources = ["arn:aws:s3:::${var.ep_upload_external_bucket}", "arn:aws:s3:::${var.ep_upload_external_bucket}/${var.ep_upload_external_prefix}/*"]
   }
 }

--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -181,3 +181,16 @@ data "aws_iam_policy_document" "s3_workflow-upload" {
     ]
   }
 }
+
+data "aws_iam_policy_document" "s3_editorial_photography_upload_external" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = ["${var.ep_upload_external_bucket}", "${var.ep_upload_external_bucket}/${var.ep_upload_external_prefix}/*"]
+  }
+}

--- a/iam_role_policy.tf
+++ b/iam_role_policy.tf
@@ -30,6 +30,11 @@ resource "aws_iam_role_policy" "ecs_goobi_s3_upload" {
   policy = "${data.aws_iam_policy_document.s3_workflow-upload.json}"
 }
 
+resource "aws_iam_role_policy" "ecs_goobi_s3_editorial_photography_upload_external" {
+  role   = "${module.goobi.goobi_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_editorial_photography_upload_external.json}"
+}
+
 resource "aws_iam_role_policy" "ecs_itm_s3_config_read" {
   role   = "${module.goobi.itm_task_role}"
   policy = "${data.aws_iam_policy_document.s3_read_workflow-configuration.json}"
@@ -38,6 +43,11 @@ resource "aws_iam_role_policy" "ecs_itm_s3_config_read" {
 resource "aws_iam_role_policy" "ecs_itm_s3_data_rw" {
   role   = "${module.goobi.itm_task_role}"
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-data.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_itm_s3_editorial_photography_upload_external" {
+  role   = "${module.goobi.itm_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_editorial_photography_upload_external.json}"
 }
 
 resource "aws_iam_role_policy" "ecs_harvester_s3_config_read" {
@@ -63,4 +73,9 @@ resource "aws_iam_role_policy" "ecs_shell_server_s3_data_rw" {
 resource "aws_iam_role_policy" "ecs_shell_server_s3_export_bagit_rw" {
   role   = "${module.goobi.shell_server_task_role}"
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_s3_editorial_photography_upload_external" {
+  role   = "${module.goobi.shell_server_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_editorial_photography_upload_external.json}"
 }

--- a/s3.tf
+++ b/s3.tf
@@ -38,9 +38,9 @@ resource "aws_s3_bucket" "workflow-export-bagit" {
   }
 }
 
-resource "aws_s3_bucket_policy" "workflow-export-bagit-archive-policy" {
+resource "aws_s3_bucket_policy" "workflow-export-bagit-external-access-policy" {
   bucket = "${aws_s3_bucket.workflow-export-bagit.id}"
-  policy = "${data.aws_iam_policy_document.allow_archive_access.json}"
+  policy = "${data.aws_iam_policy_document.allow_external_export-bagit_access.json}"
 }
 
 resource "aws_s3_bucket" "workflow-harvesting-results" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,5 @@ variable "platform_team_account_id" {}
 variable "domain_name" {
   default = "workflow.wellcomecollection.org"
 }
+
+variable "intranda_ep_user" {}

--- a/variables.tf
+++ b/variables.tf
@@ -62,9 +62,5 @@ variable "domain_name" {
 variable "intranda_ep_user" {}
 
 variable "ep_upload_external_bucket" {
-  default = "wellcomecollection-mets-ingest"
-}
-
-variable "ep_upload_external_prefix" {
-  default = "editorial-photography"
+  default = "wellcomecollection-editorial-photography"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,11 @@ variable "domain_name" {
 }
 
 variable "intranda_ep_user" {}
+
+variable "ep_upload_external_bucket" {
+  default = "wellcomecollection-mets-ingest"
+}
+
+variable "ep_upload_external_prefix" {
+  default = "editorial-photography"
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

Permissions are given in order to allow the AWS instance of Goobi to upload shoots to the EP bucket and the current production instance to upload bags to the bagit-export bucket while using credentials from the EP account.

Permissions will have to be adjusted in the other account accordingly.


