### PR TITLE
add a new bucket+permissions for bagit export to staging system

### DIFF
--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -61,6 +61,22 @@ data "aws_iam_policy_document" "s3_rw_workflow-export-bagit" {
   }
 }
 
+data "aws_iam_policy_document" "s3_rw_workflow-export-bagit-stage" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.workflow-export-bagit-stage.arn}",
+      "${aws_s3_bucket.workflow-export-bagit-stage.arn}/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "s3_rw_workflow-harvesting-results" {
   statement {
     actions = [

--- a/iam_role_policy.tf
+++ b/iam_role_policy.tf
@@ -13,6 +13,11 @@ resource "aws_iam_role_policy" "ecs_goobi_s3_export_bagit_rw" {
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit.json}"
 }
 
+resource "aws_iam_role_policy" "ecs_goobi_s3_export_bagit_stage_rw" {
+  role   = "${module.goobi.goobi_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit-stage.json}"
+}
+
 resource "aws_iam_role_policy" "ecs_goobi_s3_upload" {
   role   = "${module.goobi.goobi_task_role}"
   policy = "${data.aws_iam_policy_document.s3_workflow-upload.json}"
@@ -66,6 +71,11 @@ resource "aws_iam_role_policy" "ecs_shell_server_s3_data_rw" {
 resource "aws_iam_role_policy" "ecs_shell_server_s3_export_bagit_rw" {
   role   = "${module.goobi.shell_server_task_role}"
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_s3_export_bagit_stage_rw" {
+  role   = "${module.goobi.shell_server_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit-stage.json}"
 }
 
 resource "aws_iam_role_policy" "ecs_shell_server_s3_editorial_photography_upload_external" {

--- a/s3.tf
+++ b/s3.tf
@@ -43,6 +43,15 @@ resource "aws_s3_bucket_policy" "workflow-export-bagit-external-access-policy" {
   policy = "${data.aws_iam_policy_document.allow_external_export-bagit_access.json}"
 }
 
+resource "aws_s3_bucket" "workflow-export-bagit-stage" {
+  bucket = "wellcomecollection-workflow-export-bagit-stage"
+  acl    = "private"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "aws_s3_bucket" "workflow-harvesting-results" {
   bucket = "wellcomecollection-workflow-harvesting-results"
   acl    = "private"


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to be able to cleanly ingest into the staging storage service, a new bucket to write the bagit archives to is added.

Permissions for the storage service to read from this bucket are still needed