### PR TITLE
Add external account principals to staging bucket

### DIFF
--- a/iam_policy_document.tf
+++ b/iam_policy_document.tf
@@ -132,6 +132,16 @@ data "aws_iam_policy_document" "allow_external_export-bagit_access" {
 
 data "aws_iam_policy_document" "allow_external_export-bagit-stage_access" {
   statement {
+    actions   = ["s3:GetObject*"]
+    resources = ["${aws_s3_bucket.workflow-export-bagit-stage.arn}", "${aws_s3_bucket.workflow-export-bagit-stage.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${local.bagit_access_principles}"]
+    }
+  }
+
+  statement {
     actions = [
       "s3:ListBucket",
       "s3:GetObject",


### PR DESCRIPTION
Allows storage & platform accounts to read from staging bucket.

Fixes: https://github.com/wellcometrust/workflow/issues/192

**Note:** This is already applied.