### PR TITLE
Add machine user for doing uploads outside AWS

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -2,3 +2,33 @@ resource "aws_iam_role" "lambda_iam_role" {
   name               = "lambda_iam_role"
   assume_role_policy = "${data.aws_iam_policy_document.assume_lambda_role.json}"
 }
+
+# Machine user for editorial photography uploads
+
+resource "aws_iam_user" "workflow-upload-only" {
+  name = "workflow-upload-only"
+}
+
+resource "aws_iam_access_key" "workflow-upload-only" {
+  user = "${aws_iam_user.workflow-upload-only.name}"
+}
+
+resource "aws_iam_user_policy" "workflow-upload-only" {
+  user   = "${aws_iam_user.workflow-upload-only.name}"
+  policy = "${data.aws_iam_policy_document.workflow-upload-only.json}"
+}
+
+data "aws_iam_policy_document" "workflow-upload-only" {
+  "statement" {
+    actions = [
+      "s3:List*",
+      "s3:Get*",
+      "s3:Put*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.workflow-upload.arn}",
+      "${aws_s3_bucket.workflow-upload.arn}/*",
+    ]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,7 +34,14 @@ output "load_balancer_https_listener_arn" {
   value = "${module.load_balancer.https_listener_arn}"
 }
 
-//output "service-workflow" {
-//  value = "${aws_vpc_endpoint_service.goobi.service_name}"
+# workflow upload user (editorial photography)
+
+
+//output "upload_access_key_id" {
+//  value = "${aws_iam_access_key.workflow-upload-only.id}"
+//}
+//
+//output "upload_secret_key_id" {
+//  value = "${aws_iam_access_key.workflow-upload-only.secret}"
 //}
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,10 +1,12 @@
 provider "aws" {
   // Wellcome devs will need to swap this for the profile statement to authenticate
 
-  //  assume_role {  //    role_arn = "arn:aws:iam::299497370133:role/workflow-admin"  //  }
+  assume_role {
+    role_arn = "arn:aws:iam::299497370133:role/workflow-admin"
+  }
 
-  profile = "${var.profile}"
-  region  = "${var.region}"
+  //  profile = "${var.profile}"
+  region = "${var.region}"
 
   version = "1.52.0"
 }
@@ -18,10 +20,10 @@ terraform {
     dynamodb_table = "terraform-locktable"
 
     // Wellcome devs will need to swap this for the profile statement to authenticate
-    // role_arn = "arn:aws:iam::299497370133:role/workflow-developer"
+    role_arn = "arn:aws:iam::299497370133:role/workflow-developer"
 
-    profile = "workflow-dev"
-    region  = "eu-west-1"
+    // profile = "workflow-dev"
+    region = "eu-west-1"
   }
 }
 


### PR DESCRIPTION
In order to allow external users to upload to cloud Goobi an IAM user is required.
