### PR TITLE
increase number shellserver instances

### DIFF
--- a/goobi/main.tf
+++ b/goobi/main.tf
@@ -26,10 +26,10 @@ module "cluster" {
   ebs_size = "${var.ebs_size}"
 }
 
-module "shell_server" {
+module "shell_server_1" {
   source = "private_service"
 
-  name = "shell_server"
+  name = "shell_server_1"
 
   vpc_id          = "${var.vpc_id}"
   private_subnets = "${var.private_subnets}"
@@ -52,11 +52,119 @@ module "shell_server" {
   cluster_id = "${aws_ecs_cluster.cluster.id}"
   region     = "${var.region}"
 
-  env_vars        = "${var.shell_server_env_vars}"
+  env_vars        = "${merge(var.shell_server_env_vars,map("SHELLSERVER_CONFIG","/opt/digiverso/shellserver/conf/shellserver_1_config.properties"))}"
   env_vars_length = "${var.shell_server_env_vars_length}"
 
-  cpu    = "${var.shell_server_cpu}"
-  memory = "${var.shell_server_memory}"
+  cpu    = "${var.shell_server_1_cpu}"
+  memory = "${var.shell_server_1_memory}"
+
+  deployment_minimum_healthy_percent = "${var.shell_server_deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.shell_server_deployment_maximum_percent}"
+}
+
+module "shell_server_2" {
+  source = "private_service"
+
+  name = "shell_server_2"
+
+  vpc_id          = "${var.vpc_id}"
+  private_subnets = "${var.private_subnets}"
+
+  namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+
+  ebs_container_path = "${var.shell_server_ebs_container_path}"
+  efs_container_path = "${var.shell_server_efs_container_path}"
+
+  ebs_host_path = "${module.cluster.ebs_host_path}"
+  efs_host_path = "${module.cluster.efs_host_path}"
+
+  container_port = "${var.shell_server_container_port}"
+
+  service_egress_security_group_id = "${var.service_egress_security_group_id}"
+  interservice_security_group_id   = "${var.interservice_security_group_id}"
+
+  container_image = "${var.shell_server_container_image}"
+
+  cluster_id = "${aws_ecs_cluster.cluster.id}"
+  region     = "${var.region}"
+
+  env_vars        = "${merge(var.shell_server_env_vars,map("SHELLSERVER_CONFIG","/opt/digiverso/shellserver/conf/shellserver_2_config.properties"))}"
+  env_vars_length = "${var.shell_server_env_vars_length}"
+
+  cpu    = "${var.shell_server_2_cpu}"
+  memory = "${var.shell_server_2_memory}"
+
+  deployment_minimum_healthy_percent = "${var.shell_server_deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.shell_server_deployment_maximum_percent}"
+}
+
+module "shell_server_3" {
+  source = "private_service"
+
+  name = "shell_server_3"
+
+  vpc_id          = "${var.vpc_id}"
+  private_subnets = "${var.private_subnets}"
+
+  namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+
+  ebs_container_path = "${var.shell_server_ebs_container_path}"
+  efs_container_path = "${var.shell_server_efs_container_path}"
+
+  ebs_host_path = "${module.cluster.ebs_host_path}"
+  efs_host_path = "${module.cluster.efs_host_path}"
+
+  container_port = "${var.shell_server_container_port}"
+
+  service_egress_security_group_id = "${var.service_egress_security_group_id}"
+  interservice_security_group_id   = "${var.interservice_security_group_id}"
+
+  container_image = "${var.shell_server_container_image}"
+
+  cluster_id = "${aws_ecs_cluster.cluster.id}"
+  region     = "${var.region}"
+
+  env_vars        = "${merge(var.shell_server_env_vars,map("SHELLSERVER_CONFIG","/opt/digiverso/shellserver/conf/shellserver_3_config.properties"))}"
+  env_vars_length = "${var.shell_server_env_vars_length}"
+
+  cpu    = "${var.shell_server_3_cpu}"
+  memory = "${var.shell_server_3_memory}"
+
+  deployment_minimum_healthy_percent = "${var.shell_server_deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.shell_server_deployment_maximum_percent}"
+}
+
+module "shell_server_4" {
+  source = "private_service"
+
+  name = "shell_server_4"
+
+  vpc_id          = "${var.vpc_id}"
+  private_subnets = "${var.private_subnets}"
+
+  namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+
+  ebs_container_path = "${var.shell_server_ebs_container_path}"
+  efs_container_path = "${var.shell_server_efs_container_path}"
+
+  ebs_host_path = "${module.cluster.ebs_host_path}"
+  efs_host_path = "${module.cluster.efs_host_path}"
+
+  container_port = "${var.shell_server_container_port}"
+
+  service_egress_security_group_id = "${var.service_egress_security_group_id}"
+  interservice_security_group_id   = "${var.interservice_security_group_id}"
+
+  container_image = "${var.shell_server_container_image}"
+
+  cluster_id = "${aws_ecs_cluster.cluster.id}"
+  region     = "${var.region}"
+
+  env_vars        = "${merge(var.shell_server_env_vars,map("SHELLSERVER_CONFIG","/opt/digiverso/shellserver/conf/shellserver_4_config.properties"))}"
+  env_vars_length = "${var.shell_server_env_vars_length}"
+
+  cpu    = "${var.shell_server_4_cpu}"
+  memory = "${var.shell_server_4_memory}"
 
   deployment_minimum_healthy_percent = "${var.shell_server_deployment_minimum_healthy_percent}"
   deployment_maximum_percent         = "${var.shell_server_deployment_maximum_percent}"

--- a/goobi/outputs.tf
+++ b/goobi/outputs.tf
@@ -22,6 +22,17 @@ output "harvester_task_role" {
   value = "${module.harvester.task_role}"
 }
 
-output "shell_server_task_role" {
-  value = "${module.shell_server.task_role}"
+output "shell_server_1_task_role" {
+  value = "${module.shell_server_1.task_role}"
+}
+
+output "shell_server_2_task_role" {
+  value = "${module.shell_server_2.task_role}"
+}
+
+output "shell_server_3_task_role" {
+  value = "${module.shell_server_3.task_role}"
+}
+output "shell_server_4_task_role" {
+  value = "${module.shell_server_4.task_role}"
 }

--- a/goobi/outputs.tf
+++ b/goobi/outputs.tf
@@ -33,6 +33,7 @@ output "shell_server_2_task_role" {
 output "shell_server_3_task_role" {
   value = "${module.shell_server_3.task_role}"
 }
+
 output "shell_server_4_task_role" {
   value = "${module.shell_server_4.task_role}"
 }

--- a/goobi/private_service/main.tf
+++ b/goobi/private_service/main.tf
@@ -24,7 +24,7 @@ module "service" {
 }
 
 module "task" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/task/prebuilt/single_container+ebs+efs?ref=v11.3.1"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//ecs/modules/task/prebuilt/single_container+ebs+efs?ref=v11.8.1"
 
   aws_region = "${var.region}"
   task_name  = "${var.name}"

--- a/goobi/variables.tf
+++ b/goobi/variables.tf
@@ -67,8 +67,14 @@ variable "shell_server_env_vars" {
 
 variable "shell_server_env_vars_length" {}
 
-variable "shell_server_cpu" {}
-variable "shell_server_memory" {}
+variable "shell_server_1_cpu" {}
+variable "shell_server_1_memory" {}
+variable "shell_server_2_cpu" {}
+variable "shell_server_2_memory" {}
+variable "shell_server_3_cpu" {}
+variable "shell_server_3_memory" {}
+variable "shell_server_4_cpu" {}
+variable "shell_server_4_memory" {}
 variable "shell_server_deployment_minimum_healthy_percent" {}
 variable "shell_server_deployment_maximum_percent" {}
 

--- a/iam_role_policy.tf
+++ b/iam_role_policy.tf
@@ -58,28 +58,107 @@ resource "aws_iam_role_policy" "ecs_harvester_s3_rw_workflow-harvesting-results"
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-harvesting-results.json}"
 }
 
-resource "aws_iam_role_policy" "ecs_shell_server_s3_config_read" {
-  role   = "${module.goobi.shell_server_task_role}"
+# shell_server_1
+resource "aws_iam_role_policy" "ecs_shell_server_1_s3_config_read" {
+  role   = "${module.goobi.shell_server_1_task_role}"
   policy = "${data.aws_iam_policy_document.s3_read_workflow-configuration.json}"
 }
 
-resource "aws_iam_role_policy" "ecs_shell_server_s3_data_rw" {
-  role   = "${module.goobi.shell_server_task_role}"
+resource "aws_iam_role_policy" "ecs_shell_server_1_s3_data_rw" {
+  role   = "${module.goobi.shell_server_1_task_role}"
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-data.json}"
 }
 
-resource "aws_iam_role_policy" "ecs_shell_server_s3_export_bagit_rw" {
-  role   = "${module.goobi.shell_server_task_role}"
+resource "aws_iam_role_policy" "ecs_shell_server_1_s3_export_bagit_rw" {
+  role   = "${module.goobi.shell_server_1_task_role}"
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit.json}"
 }
 
-resource "aws_iam_role_policy" "ecs_shell_server_s3_export_bagit_stage_rw" {
-  role   = "${module.goobi.shell_server_task_role}"
+resource "aws_iam_role_policy" "ecs_shell_server_1_s3_export_bagit_stage_rw" {
+  role   = "${module.goobi.shell_server_1_task_role}"
   policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit-stage.json}"
 }
 
-resource "aws_iam_role_policy" "ecs_shell_server_s3_editorial_photography_upload_external" {
-  role   = "${module.goobi.shell_server_task_role}"
+resource "aws_iam_role_policy" "ecs_shell_server_1_s3_editorial_photography_upload_external" {
+  role   = "${module.goobi.shell_server_1_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_editorial_photography_upload_external.json}"
+}
+
+# shell_server_2
+resource "aws_iam_role_policy" "ecs_shell_server_2_s3_config_read" {
+  role   = "${module.goobi.shell_server_2_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_read_workflow-configuration.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_2_s3_data_rw" {
+  role   = "${module.goobi.shell_server_2_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-data.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_2_s3_export_bagit_rw" {
+  role   = "${module.goobi.shell_server_2_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_2_s3_export_bagit_stage_rw" {
+  role   = "${module.goobi.shell_server_2_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit-stage.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_2_s3_editorial_photography_upload_external" {
+  role   = "${module.goobi.shell_server_2_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_editorial_photography_upload_external.json}"
+}
+
+# shell_server_3
+resource "aws_iam_role_policy" "ecs_shell_server_3_s3_config_read" {
+  role   = "${module.goobi.shell_server_3_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_read_workflow-configuration.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_3_s3_data_rw" {
+  role   = "${module.goobi.shell_server_3_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-data.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_3_s3_export_bagit_rw" {
+  role   = "${module.goobi.shell_server_3_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_3_s3_export_bagit_stage_rw" {
+  role   = "${module.goobi.shell_server_3_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit-stage.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_3_s3_editorial_photography_upload_external" {
+  role   = "${module.goobi.shell_server_3_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_editorial_photography_upload_external.json}"
+}
+
+# shell_server_4
+resource "aws_iam_role_policy" "ecs_shell_server_4_s3_config_read" {
+  role   = "${module.goobi.shell_server_4_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_read_workflow-configuration.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_4_s3_data_rw" {
+  role   = "${module.goobi.shell_server_4_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-data.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_4_s3_export_bagit_rw" {
+  role   = "${module.goobi.shell_server_4_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_4_s3_export_bagit_stage_rw" {
+  role   = "${module.goobi.shell_server_4_task_role}"
+  policy = "${data.aws_iam_policy_document.s3_rw_workflow-export-bagit-stage.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_shell_server_4_s3_editorial_photography_upload_external" {
+  role   = "${module.goobi.shell_server_4_task_role}"
   policy = "${data.aws_iam_policy_document.s3_editorial_photography_upload_external.json}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ module "goobi" {
   goobi_ebs_container_path = "/ebs"
 
   goobi_app_cpu    = "6144"
-  goobi_app_memory = "16384"
+  goobi_app_memory = "8192"
 
   goobi_sidecar_cpu    = "128"
   goobi_sidecar_memory = "256"
@@ -195,7 +195,7 @@ module "goobi" {
   harvester_ebs_container_path = "/ebs"
 
   harvester_app_cpu    = "512"
-  harvester_app_memory = "3072"
+  harvester_app_memory = "2048"
 
   harvester_sidecar_cpu    = "128"
   harvester_sidecar_memory = "256"

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,7 @@ module "goobi" {
   harvester_ebs_container_path = "/ebs"
 
   harvester_app_cpu    = "512"
-  harvester_app_memory = "4096"
+  harvester_app_memory = "3072"
 
   harvester_sidecar_cpu    = "128"
   harvester_sidecar_memory = "256"

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "goobi" {
 
   shell_server_3_cpu    = "1024"
   shell_server_3_memory = "3027"
-  
+
   shell_server_4_cpu    = "1024"
   shell_server_4_memory = "3027"
 

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ module "goobi" {
     S3_DATA_BUCKET  = "${aws_s3_bucket.workflow-data.bucket}"
   }
 
-  shell_server_env_vars_length = "4"
+  shell_server_env_vars_length = "5"
 
   shell_server_efs_container_path = "/efs"
   shell_server_ebs_container_path = "/ebs"

--- a/main.tf
+++ b/main.tf
@@ -129,8 +129,17 @@ module "goobi" {
   shell_server_efs_container_path = "/efs"
   shell_server_ebs_container_path = "/ebs"
 
-  shell_server_cpu    = "1024"
-  shell_server_memory = "7168"
+  shell_server_1_cpu    = "1024"
+  shell_server_1_memory = "7168"
+
+  shell_server_2_cpu    = "1024"
+  shell_server_2_memory = "3027"
+
+  shell_server_3_cpu    = "1024"
+  shell_server_3_memory = "3027"
+  
+  shell_server_4_cpu    = "1024"
+  shell_server_4_memory = "3027"
 
   shell_server_deployment_minimum_healthy_percent = "0"
   shell_server_deployment_maximum_percent         = "100"

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ module "goobi" {
   goobi_ebs_container_path = "/ebs"
 
   goobi_app_cpu    = "6144"
-  goobi_app_memory = "8192"
+  goobi_app_memory = "7168"
 
   goobi_sidecar_cpu    = "128"
   goobi_sidecar_memory = "256"


### PR DESCRIPTION
### What is this PR trying to achieve?

In order not to have a too tiny bottleneck, the load for image conversion/validation etc. should be spread over more shellserver instances until the new solution with easier scaling has been finished.

The branch has already been applied and LB rules fixed manually.

count() does not work for modules in terraform < 0.12, so the configuration settings have been multiplied.